### PR TITLE
remove absolute path of ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ import (
 )
 
 func main() {
-	ffmpegPath := "/usr/local/bin/ffmpeg"
 	srcPath := "/assets/raw/movie.mov"
 	targetPath := "/assets/hls"
 	resOptions := []string{"480p", "720p"}
@@ -31,7 +30,7 @@ func main() {
 	hlsPlaylist.GeneratePlaylist(variants, targetPath, "")
 
 	for _, res := range resOptions {
-		hls.GenerateHLS(ffmpeg, srcPath, targetPath, res)
+		hls.GenerateHLS(srcPath, targetPath, res)
 	}
 }
 ```

--- a/hls.go
+++ b/hls.go
@@ -9,19 +9,19 @@ import (
 
 // GenerateHLS will generate HLS file based on resolution presets.
 // The available resolutions are: 360p, 480p, 720p and 1080p.
-func GenerateHLS(ffmpegPath, srcPath, targetPath, resolution string) error {
+func GenerateHLS(srcPath, targetPath, resolution string) error {
 	options, err := getOptions(srcPath, targetPath, resolution)
 	if err != nil {
 		return err
 	}
 
-	return GenerateHLSCustom(ffmpegPath, options)
+	return GenerateHLSCustom(options)
 }
 
 // GenerateHLSCustom will generate HLS using the flexible options params.s
 // options is array of string that accepted by ffmpeg command
-func GenerateHLSCustom(ffmpegPath string, options []string) error {
-	cmd := exec.Command(ffmpegPath, options...)
+func GenerateHLSCustom(options []string) error {
+	cmd := exec.Command("ffmpeg", options...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/hls_test.go
+++ b/hls_test.go
@@ -11,9 +11,8 @@ func TestCmdExecuteFfmpeg(t *testing.T) {
 
 	targetPath := path.Join(base, "static")
 	srcPath := path.Join(base, "static", "sample.mov")
-	ffmpegPath := "/usr/local/bin/ffmpeg"
 
-	err := GenerateHLS(ffmpegPath, srcPath, targetPath, "480p")
+	err := GenerateHLS(srcPath, targetPath, "480p")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Hi rendyfebry:
I think there's no need to specify the absolute path of `ffmpeg`, as the [GoDoc](https://golang.org/pkg/os/exec/#Command) says about `exec.Command()` function : `If name contains no path separators, Command uses LookPath to resolve name to a complete path if possible. Otherwise it uses name directly as Path.`  and the 2 examples in the doc doesn't specify the absolute path of executable file.  

as long as `ffmpeg` is installed on the host machine, this program works fine!








